### PR TITLE
Fix the definition of \DeleteFile for non-windows system

### DIFF
--- a/source/minted.dtx
+++ b/source/minted.dtx
@@ -1082,7 +1082,7 @@ f.close()
     \ifthenelse{\equal{#1}{}}{\immediate\write18{del "#2"}}%
       {\immediate\write18{del "#1\@backslashchar #2"}}}
 \else
-  \providecommand{\DeleteFile}[2]{%
+  \providecommand{\DeleteFile}[2][]{%
     \ifthenelse{\equal{#1}{}}{\immediate\write18{rm "#2"}}%
       {\immediate\write18{rm "#1/#2"}}}
 \fi


### PR DESCRIPTION
This macro has an optional argument, however the empty `[]` was omitted for non-windows case. This case the harmless error message such as `rm: cannot remove jobname.aex/: Not a directory`. This may cause other unexpected problem as without the optional argument, the macro can eat one more token
