### PR TITLE
Passthrough the `labelposition' fancyvrb option.

### DIFF
--- a/source/minted.sty
+++ b/source/minted.sty
@@ -631,6 +631,7 @@
 \minted@def@optfv{fontseries}
 \minted@def@optfv{formatcom}
 \minted@def@optfv{label}
+\minted@def@optfv{labelposition}
 \minted@def@optfv@switch{numberblanklines}
 \minted@def@optfv@switch{showspaces}
 \minted@def@optfv@switch{resetmargins}


### PR DESCRIPTION
This option is in the documentation, but without this change it
won't compile.