### PR TITLE
Use portable `command -v` to detect installed programs

### DIFF
--- a/source/minted.sty
+++ b/source/minted.sty
@@ -194,7 +194,7 @@
     \immediate\closein\minted@appexistsfile
     \DeleteFile{\minted@jobname.aex}%
   \else
-    \ShellEscape{which #1 && touch \minted@jobname.aex}%
+    \ShellEscape{command -v #1 && touch \minted@jobname.aex}%
     \IfFileExists{\minted@jobname.aex}%
       {\AppExiststrue
         \DeleteFile{\minted@jobname.aex}}%


### PR DESCRIPTION
The `which` utility is not guaranteed to be installed, and if it is, its behavior is not portable either.

Conversely, the `command -v` shell builtin is required to exist in all POSIX 2008 compliant shells, and is thus guaranteed to work everywhere.

Compiling a document using `minted` on a system without `which` results in:
```
sh: line 1: which : command not found

! Package minted Error: You must have `pygmentize' installed to use this package.

See the minted package documentation for explanation.
Type  H <return>  for immediate help.
```