### PR TITLE
Convert all timestamps to fix the comparison

### DIFF
--- a/latex/minted/minted.dtx
+++ b/latex/minted/minted.dtx
@@ -1805,6 +1805,10 @@
   \endgroup
 \fi
 %    \end{macrocode}
+% To unify the structure of this macro to be able to compare it using |\ifx| it has to be converted to a string.
+%    \begin{macrocode}
+\xdef\minted@timestamp{\expandafter\detokenize\expandafter{\minted@timestamp}}
+%    \end{macrocode}
 % \end{macro}
 %
 %
@@ -2519,6 +2523,12 @@
   \ifx\minted@executable@version\relax
     \expandafter\minted@detectconfig@noexecutable
   \else
+%    \end{macrocode}
+% The category codes inside the time stamps may differ depending on how the timestamp was defined.
+% They are converted to strings so that the comparison will not fail depending on the category codes.
+%    \begin{macrocode}
+    \xdef\minted@config@timestamp{\expandafter\detokenize\expandafter{\minted@config@timestamp}}%
+    \xdef\minted@executable@timestamp{\expandafter\detokenize\expandafter{\minted@executable@timestamp}}%
     \expandafter\minted@detectconfig@ii
   \fi}
 \def\minted@detectconfig@noexecutable{%


### PR DESCRIPTION
I was thinking about opening an issue but guess it's easier to explain that way … 

If you want an issue in addition, I can open one s well.  This may be related to #401 depends a bit on the specific setup.

Actually the test for the timestamp is failing in some setups, e.g. using lualatex. The timestamp to compare with is a string and the one read out of the config file will contain letters. As `\ifx` is comparing both the test will return false, though the timestamps would match.  One option to fix this would be replacing the test via `\ifx` by something different, e.g. `\str_if_eq` but to match the rest of the packages structure I decided to do it the `\detokenize` way. 


Offtopic, but as I already write here:
Thanks for all the work! I love this! And I do even more now that shell escape is no longer required. So I will no longer have to create weird workarounds for limited setups. 