### PR TITLE
Fixed missing braces around passed on key values

### DIFF
--- a/latex/minted/minted.dtx
+++ b/latex/minted/minted.dtx
@@ -951,7 +951,7 @@
 %   \item[breakafter (string) (\meta{none})]
 %     Break lines after specified characters, not just at spaces, when \texttt{breaklines=true}.
 %
-% For example, \texttt{breakafter=-/} would allow breaks after any hyphens or slashes.  Special characters given to \texttt{breakafter} should be backslash-escaped (usually \texttt{\hashchar}, \texttt{\{}, \texttt{\}}, \texttt{\%}, \texttt{[}, \texttt{]}; the backslash \texttt{\textbackslash} may be obtained via \texttt{\textbackslash\textbackslash}).
+% For example, \texttt{breakafter=-/} would allow breaks after any hyphens or slashes.  Special characters given to \texttt{breakafter} should be backslash-escaped (usually \texttt{\hashchar}, \texttt{\{}, \texttt{\}}, \texttt{\%}, \texttt{[}, \texttt{]}, and the comma \texttt{,}; the backslash \texttt{\textbackslash} may be obtained via \texttt{\textbackslash\textbackslash}).
 %
 % For an alternative, see \texttt{breakbefore}.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
 %
@@ -1004,7 +1004,7 @@
 %   \item[breakbefore (string) (\meta{none})]
 %     Break lines before specified characters, not just at spaces, when \texttt{breaklines=true}.
 %
-% For example, \texttt{breakbefore=A} would allow breaks before capital A's.  Special characters given to \texttt{breakbefore} should be backslash-escaped (usually \texttt{\hashchar}, \texttt{\{}, \texttt{\}}, \texttt{\%}, \texttt{[}, \texttt{]}; the backslash \texttt{\textbackslash} may be obtained via \texttt{\textbackslash\textbackslash}).
+% For example, \texttt{breakbefore=A} would allow breaks before capital A's.  Special characters given to \texttt{breakbefore} should be backslash-escaped (usually \texttt{\hashchar}, \texttt{\{}, \texttt{\}}, \texttt{\%}, \texttt{[}, \texttt{]}, and the comma \texttt{,}; the backslash \texttt{\textbackslash} may be obtained via \texttt{\textbackslash\textbackslash}).
 %
 %  For an alternative, see \texttt{breakafter}.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
 %

--- a/latex/minted/minted.dtx
+++ b/latex/minted/minted.dtx
@@ -2751,15 +2751,15 @@
   \def\minted@do@i##1##2{%
     \pgfkeys{%
       /minted/##1/.cd,
-      #1/.code=
+      #1/.code={%
         \def\minted@tmp{####1}%
         \ifx\minted@tmp\minted@const@pgfkeysnovalue
           \begingroup\fvset{#1}\endgroup
           \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1,}%
         \else
-          \begingroup\fvset{#1=####1}\endgroup
-          \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1=####1,}%
-        \fi,
+          \begingroup\fvset{#1={####1}}\endgroup
+          \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1={####1},}%
+        \fi},
     }%
   }%
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
@@ -2767,7 +2767,7 @@
   \else
     \pgfkeys{%
       /minted/global/.cd,
-      #1=#2,
+      #1={#2},
     }%
   \fi}
 \def\minted@usefvopts{%
@@ -2800,7 +2800,7 @@
       \expandafter{\minted@tmp}{mathescape}%
   \fi}
 \def\minted@useadditionalfvoptsnopy@fvsetvk#1#2{%
-  \fvset{#2=#1}}
+  \fvset{#2={#1}}}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2849,12 +2849,12 @@
     \if\relax\detokenize{#1}\relax
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=\expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{####1},
+        #2/.code={\expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{####1}},
       }%
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=
+        #2/.code={%
           \def\minted@tmp{####1}%
           \ifx\minted@tmp\minted@const@pgfkeysnovalue
             \expandafter\let\csname minted@pyopt@##1##2@#2\endcsname\minted@tmp
@@ -2862,7 +2862,7 @@
             #1{minted@pyopt@##1##2@#2}{####1}%
           \else
             \expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{#1{####1}}%
-          \fi\fi,
+          \fi\fi},
       }%
     \fi
     \ifx\minted@const@pgfkeysnovalue#4\relax
@@ -2873,14 +2873,14 @@
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.default=#4,
+        #2/.default={#4},
       }%
     \fi
   }%
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
   \pgfkeys{%
     /minted/global/.cd,
-    #2=#3,
+    #2={#3},
   }}
 \def\mintedpyoptvalueof#1{%
   \ifbool{minted@isinline}%
@@ -2954,13 +2954,13 @@
     \if\relax\detokenize{#1}\relax
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=\expandafter\def\csname minted@texopt@##1##2@#2\endcsname{####1},
+        #2/.code={\expandafter\def\csname minted@texopt@##1##2@#2\endcsname{####1}},
         #2/.value required,
       }%
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=
+        #2/.code={%
           \def\minted@tmp{####1}%
           \ifx\minted@tmp\minted@const@pgfkeysnovalue
             \expandafter\let\csname minted@texopt@##1##2@#2\endcsname\minted@tmp
@@ -2968,7 +2968,7 @@
             #1{minted@texopt@##1##2@#2}{####1}%
           \else
             \expandafter\def\csname minted@texopt@##1##2@#2\endcsname{#1{####1}}%
-          \fi\fi,
+          \fi\fi},
         #2/.value required,
       }%
     \fi
@@ -2976,7 +2976,7 @@
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
   \pgfkeys{%
     /minted/global/.cd,
-    #2=#3,
+    #2={#3},
   }}
 \def\mintedtexoptvalueof#1{%
   \ifbool{minted@isinline}%
@@ -3898,7 +3898,7 @@
 % \begin{macro}{\usemintedstyle}
 % Set style.  This is a holdover from \mintedpkg\ v1, before |\setminted| could be used to set the style.
 %    \begin{macrocode}
-\newcommand{\usemintedstyle}[2][]{\setminted[#1]{style=#2}}
+\newcommand{\usemintedstyle}[2][]{\setminted[#1]{style={#2}}}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/latex/minted/minted.sty
+++ b/latex/minted/minted.sty
@@ -611,15 +611,15 @@
   \def\minted@do@i##1##2{%
     \pgfkeys{%
       /minted/##1/.cd,
-      #1/.code=
+      #1/.code={%
         \def\minted@tmp{####1}%
         \ifx\minted@tmp\minted@const@pgfkeysnovalue
           \begingroup\fvset{#1}\endgroup
           \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1,}%
         \else
-          \begingroup\fvset{#1=####1}\endgroup
-          \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1=####1,}%
-        \fi,
+          \begingroup\fvset{#1={####1}}\endgroup
+          \minted@apptoprovidecs{minted@fvoptlist@##1##2}{#1={####1},}%
+        \fi},
     }%
   }%
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
@@ -627,7 +627,7 @@
   \else
     \pgfkeys{%
       /minted/global/.cd,
-      #1=#2,
+      #1={#2},
     }%
   \fi}
 \def\minted@usefvopts{%
@@ -660,7 +660,7 @@
       \expandafter{\minted@tmp}{mathescape}%
   \fi}
 \def\minted@useadditionalfvoptsnopy@fvsetvk#1#2{%
-  \fvset{#2=#1}}
+  \fvset{#2={#1}}}
 \def\minted@pgfkeyscreate@py#1#2{%
   \minted@forcsvlist{\minted@pgfkeycreate@py{#1}}{#2}}
 \begingroup
@@ -698,12 +698,12 @@
     \if\relax\detokenize{#1}\relax
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=\expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{####1},
+        #2/.code={\expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{####1}},
       }%
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=
+        #2/.code={%
           \def\minted@tmp{####1}%
           \ifx\minted@tmp\minted@const@pgfkeysnovalue
             \expandafter\let\csname minted@pyopt@##1##2@#2\endcsname\minted@tmp
@@ -711,7 +711,7 @@
             #1{minted@pyopt@##1##2@#2}{####1}%
           \else
             \expandafter\def\csname minted@pyopt@##1##2@#2\endcsname{#1{####1}}%
-          \fi\fi,
+          \fi\fi},
       }%
     \fi
     \ifx\minted@const@pgfkeysnovalue#4\relax
@@ -722,14 +722,14 @@
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.default=#4,
+        #2/.default={#4},
       }%
     \fi
   }%
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
   \pgfkeys{%
     /minted/global/.cd,
-    #2=#3,
+    #2={#3},
   }}
 \def\mintedpyoptvalueof#1{%
   \ifbool{minted@isinline}%
@@ -790,13 +790,13 @@
     \if\relax\detokenize{#1}\relax
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=\expandafter\def\csname minted@texopt@##1##2@#2\endcsname{####1},
+        #2/.code={\expandafter\def\csname minted@texopt@##1##2@#2\endcsname{####1}},
         #2/.value required,
       }%
     \else
       \pgfkeys{%
         /minted/##1/.cd,
-        #2/.code=
+        #2/.code={%
           \def\minted@tmp{####1}%
           \ifx\minted@tmp\minted@const@pgfkeysnovalue
             \expandafter\let\csname minted@texopt@##1##2@#2\endcsname\minted@tmp
@@ -804,7 +804,7 @@
             #1{minted@texopt@##1##2@#2}{####1}%
           \else
             \expandafter\def\csname minted@texopt@##1##2@#2\endcsname{#1{####1}}%
-          \fi\fi,
+          \fi\fi},
         #2/.value required,
       }%
     \fi
@@ -812,7 +812,7 @@
   \minted@forcsvlist{\minted@do}{\minted@optscopes}%
   \pgfkeys{%
     /minted/global/.cd,
-    #2=#3,
+    #2={#3},
   }}
 \def\mintedtexoptvalueof#1{%
   \ifbool{minted@isinline}%
@@ -1532,7 +1532,7 @@
     \edef\minted@lexer{#1}%
     \pgfkeys{/minted/lexerinline/.cd,#2}%
     \let\minted@lexer\minted@tmplexer}}
-\newcommand{\usemintedstyle}[2][]{\setminted[#1]{style=#2}}
+\newcommand{\usemintedstyle}[2][]{\setminted[#1]{style={#2}}}
 \def\mintinline{%
   \FVExtraRobustCommand\RobustMintInline\FVExtraUnexpandedReadStarOArgMArgBVArg}
 \FVExtrapdfstringdefDisableCommands{%


### PR DESCRIPTION
The received values of some keys or options may contain unescaped comma (`,`) and/or equal (`=`) characters which may break key-value processing, for example `breakbefore`, `breakafter`, and `break...symbol(pre|post)` options.

So in user input, such values need to be enclosed in a pair of braces, e.g., `breakafter={,]}`. Those braces are then removed in the extracted values (`,]`). Then to pass on them to other keys/options, the values need to be braced again.

This PR adds the required braces around forwarded key values, and updates `breakbefore` and `breakafter` docs to sync with https://github.com/gpoore/fvextra/commit/16de52d (breakbefore and breakafter now support the escaped comma \, (closes <span>#15</span>), 2022-11-10).

Example
```tex
\documentclass{article}
\usepackage{minted}
\setminted{breakafter={,]}} % ! Package keyval Error: ] undefined.
\setminted{breakafter={,\]}} % ! Missing \endcsname inserted. <to be read again> \protect
\begin{document}
\end{document}
```
- Before: error(s) raised.
- After: no errors.