### PR TITLE
Fixed docs of `breakbeforeinrun` and `breakafterinrun`

### DIFF
--- a/latex/minted/minted.dtx
+++ b/latex/minted/minted.dtx
@@ -959,8 +959,8 @@
 %   \end{minted}
 % \end{longexample}
 %
-%   \item[breakafterinrun] (boolean) (true)
-%     When \texttt{breakafter} is used, group all adjacent identical characters together, and only allow a break after the last character.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
+%   \item[breakafterinrun] (boolean) (false)
+%     When \texttt{breakafter} is used, insert breaks within runs of identical characters.  If \texttt{false}, treat sequences of identical characters as a unit that cannot contain breaks.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
 %
 %
 %   \item[breakaftersymbolpost (string) (\meta{none})]
@@ -1012,8 +1012,8 @@
 %   \end{minted}
 % \end{longexample}
 %
-%   \item[breakbeforeinrun] (boolean) (true)
-%     When \texttt{breakbefore} is used, group all adjacent identical characters together, and only allow a break before the first character.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
+%   \item[breakbeforeinrun] (boolean) (false)
+%     When \texttt{breakbefore} is used, insert breaks within runs of identical characters.  If \texttt{false}, treat sequences of identical characters as a unit that cannot contain breaks.  When \texttt{breakbefore} and \texttt{breakafter} are used for the same character, \texttt{breakbeforeinrun} and \texttt{breakafterinrun} must both have the same setting.
 %
 %
 %   \item[breakbeforesymbolpost (string) (\meta{none})]


### PR DESCRIPTION
The option renaming

    s/break(before|after)group/break(before|after)inrun/

also flipped their behavior and default values, see gpoore/fvextra@08f35ea (replaced breakbeforegroup with breakbeforeinrun; replaced breakaftergroup with breakafterinrun, 2022-11-14)

But ceedb97 (added support for fvextra options breakafterinrun and breakbeforeinrun (closes <span>#358</span>), 2023-07-14) only did a naive renaming. This commit fixed the gap.