### PR TITLE
Fix misspelt \@firstoftwo

### DIFF
--- a/latex/minted/minted.dtx
+++ b/latex/minted/minted.dtx
@@ -2569,7 +2569,7 @@
 \def\minted@detectconfig@noexecutableorerrlog{%
   \global\boolfalse{minted@canexec}%
   \ifnum\csname c_sys_shell_escape_int\endcsname=1\relax
-    \expandafter\@firstofttwo
+    \expandafter\@firstoftwo
   \else
     \expandafter\@secondoftwo
   \fi

--- a/latex/minted/minted.sty
+++ b/latex/minted/minted.sty
@@ -474,7 +474,7 @@
 \def\minted@detectconfig@noexecutableorerrlog{%
   \global\boolfalse{minted@canexec}%
   \ifnum\csname c_sys_shell_escape_int\endcsname=1\relax
-    \expandafter\@firstofttwo
+    \expandafter\@firstoftwo
   \else
     \expandafter\@secondoftwo
   \fi


### PR DESCRIPTION
It appears fd33ab0 introduced a spelling mistake  where `\@firstoftwo` is spelt with two t's as `\@firstofttwo`.

This took me an extraordinary amount of time to notice two t's when I was debugging =)