### PR TITLE
Add missing argument for ArgParser in python 3.14

### DIFF
--- a/python/latexminted/cmdline.py
+++ b/python/latexminted/cmdline.py
@@ -22,7 +22,7 @@ from typing import Callable
 
 
 class ArgParser(argparse.ArgumentParser):
-    def __init__(self, *, prog: str):
+    def __init__(self, *, prog: str, color: bool = True):
         super().__init__(
             prog=prog,
             allow_abbrev=False,


### PR DESCRIPTION
My system got updated lately and I kept getting the following error:

```python
Traceback (most recent call last):
  File "/Library/TeX/texbin/latexminted", line 372, in <module>
    main()
    ~~~~^^
  File "/usr/local/texlive/2025/texmf-dist/scripts/minted/latexminted-0.5.0-py3-none-any.whl/latexminted/cmdline.py", line 148, in main
    parser.add_command('batch', help='Batch process highlight, styledef, and clean', func=batch)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/texlive/2025/texmf-dist/scripts/minted/latexminted-0.5.0-py3-none-any.whl/latexminted/cmdline.py", line 41, in add_command
    parser = self._command_subparsers.add_parser(name, help=help)
  File "/opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 1268, in add_parser
    parser = self._parser_class(**kwargs)
TypeError: ArgParser.__init__() got an unexpected keyword argument 'color'
```

It turns out that python 3.14 forwards a new color argument to the `ArgParser` class. With this addition, I managed to get my version to work. But I do not know if this is backwards compatible with other python versions. I also did not dig deeper on what this flag does.